### PR TITLE
interface_ip returns null; use private_v4 instead

### DIFF
--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -126,8 +126,8 @@ def get_host_groups(inventory, refresh=False, cloud=None):
 
 def append_hostvars(hostvars, groups, key, server, namegroup=False):
     hostvars[key] = dict(
-        ansible_ssh_host=server['interface_ip'],
-        ansible_host=server['interface_ip'],
+        ansible_ssh_host=server['private_v4'],
+        ansible_host=server['private_v4'],
         openstack=server)
 
     metadata = server.get('metadata', {})
@@ -154,7 +154,7 @@ def get_host_groups_from_cloud(inventory):
 
     for server in inventory.list_hosts(**list_args):
 
-        if 'interface_ip' not in server:
+        if 'private_v4' not in server:
             continue
         firstpass[server['name']].append(server)
     for name, servers in firstpass.items():


### PR DESCRIPTION
interface_ip does not contain anything.
IP address is stored in private_v4 element.